### PR TITLE
Enable Dual Compiling for Swift 3 and 4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 import PackageDescription
 
 let package = Package(
-    name: "Moderator"
+    name: "Moderator",
+    swiftLanguageVersions: [3, 4]
 )

--- a/Sources/Parsers.swift
+++ b/Sources/Parsers.swift
@@ -210,7 +210,7 @@ extension Argument where Value == Bool {
 	/// Counts the number of times an option argument occurs.
 	public func count() -> Argument<Int> {
 		return Argument<Int>(usage: self.usage) { args in
-			let result = try self.map { $0 ? () : nil }.repeat().parse(args)
+			let result = try self.map { $0 ? true : nil }.repeat().parse(args)
 			return (result.value.count, result.remainder)
 		}
 	}

--- a/Sources/SwiftCompat.swift
+++ b/Sources/SwiftCompat.swift
@@ -1,0 +1,22 @@
+#if swift(>=4.0)
+// No Swift 4 back compat mode.
+// This keeps the compiler happy.
+#elseif swift(>=3.0)
+extension String {
+	func dropFirst(_ n: Int = 1) -> String.CharacterView {
+		return self.characters.dropFirst(n)
+	}
+
+	var first: Character? {
+		return self.characters.first
+	}
+
+	var count: Int {
+		return self.characters.count
+	}
+	
+	func split(separator: Character, maxSplits: Int = Int.max, omittingEmptySubsequences: Bool = true) -> [String.CharacterView] {
+		return self.characters.split(separator: separator, maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences) 
+	}
+}
+#endif


### PR DESCRIPTION
This library is well aimed at Linux and the Raspberry Pi in particular, but the Raspberry Pi is stuck on Swift 3.1.1 if targeting the Zero.

This change enables it to build/test for both Swift 3 and 4 at the same time. The code remains mostly Swift 4, but uses wrappers around the Swift 3 versions of functions to allow most of the Swift 4 code to continue to operate.

The one unfortunate change is that Swift 3.1.1 doesn’t like the “$0 ? () : nil” syntax in count()’s map. While it technically uses fewer bytes marking the entries with empty tuples, it creates issues resolving types in Swift 3. As a workaround, we can just use a Bool instead.

If I can fix this last issue later a different way, I will.